### PR TITLE
Update no longer worked with 3.0.12 and beyond

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER aheil
 ENV TS_VERSION LATEST
 
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install libnspr4 spidermonkey-bin wget ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install libnspr4 bzip2 spidermonkey-bin wget ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && wget -O /usr/bin/jsawk https://raw.githubusercontent.com/micha/jsawk/master/jsawk \
     && chmod +x /usr/bin/jsawk \

--- a/start-teamspeak3.sh
+++ b/start-teamspeak3.sh
@@ -25,5 +25,5 @@ else
   TS3ARGS="createinifile=1"
 fi
 
-exec ./ts3server_linux_amd64 $TS3ARGS
+exec ./ts3server $TS3ARGS
 

--- a/start-teamspeak3.sh
+++ b/start-teamspeak3.sh
@@ -8,12 +8,12 @@ esac
 
 cd /data
 
-TARFILE=teamspeak3-server_linux-amd64-${TS_VERSION}.tar.gz
+TARFILE=teamspeak3-server_linux_amd64-${TS_VERSION}.tar.bz2
 
 if [ ! -e ${TARFILE} ]; then
   echo "Downloading ${TARFILE} ..."
   wget -q http://dl.4players.de/ts/releases/${TS_VERSION}/${TARFILE} \
-  && tar -x -f ${TARFILE} --strip-components=1
+  && tar -j -x -f ${TARFILE} --strip-components=1
 fi
 
 export LD_LIBRARY_PATH=/data


### PR DESCRIPTION
Hi, I have created a fix for a recent change on the teamspeak download site.

- Changed tar.gz to tar.bz2
- Added -j to tar extract command for bzip2
- File prefix changed to teamspeak3-server_linux_amd64 instead of teamspeak3-server_linux-amd64.