### PR TITLE
Ignore certificate in start-teamspeak3.sh

### DIFF
--- a/start-teamspeak3.sh
+++ b/start-teamspeak3.sh
@@ -2,7 +2,7 @@
 
 case $TS_VERSION in
   LATEST)
-    export TS_VERSION=`wget -O - https://www.server-residenz.com/tools/ts3versions.json | jsawk -n 'out(this.latest)'`
+    export TS_VERSION=`wget –no-check-certificate -O - https://www.server-residenz.com/tools/ts3versions.json | jsawk -n 'out(this.latest)'`
     ;;
 esac
 


### PR DESCRIPTION
When I run your docker container like you suggested on docker-hub the certificate of 'www.server-residenz.com' is not trusted.
It would be suitable to ignore the certificate warning by using the '-no-check-certificate' flag

FYI: LogOutput
[rancher@rancher ~]$ docker run -d -v ~/_data/:/data -p 9987:9987/udp -p 10011:10011 -p 30033:30033 --name=ts3-server aheil/teamspeak3-server
b504c5d5d3db15242f1ba9694313c947d34e09b9a4c3876c3d6085b77f09b63b
[rancher@rancher ~]$ docker logs -f b504c5d5d3db15242f1ba9694313c947d34e09b9a4c3876c3d6085b77f09b63b
--2016-12-08 14:42:45--  https://www.server-residenz.com/tools/ts3versions.json
Resolving www.server-residenz.com (www.server-residenz.com)... 144.76.125.99
Connecting to www.server-residenz.com (www.server-residenz.com)|144.76.125.99|:443... connected.
ERROR: The certificate of `www.server-residenz.com' is not trusted.
Downloading teamspeak3-server_linux_amd64-.tar.bz2 ...
/start-teamspeak3: line 28: /data/ts3server: No such file or directory